### PR TITLE
Add composer-uninstall command

### DIFF
--- a/zsh/init/20_functions.zsh
+++ b/zsh/init/20_functions.zsh
@@ -102,3 +102,11 @@ laravel_refresh() {
   php artisan optimize
   php artisan config:cache
 }
+
+composer-uninstall () {
+  composer remove --no-update "$@"
+  composer update --dry-run |
+  grep -Eo -e '- Uninstalling\s+\S+' |
+  cut -d' ' -f3 |
+  xargs composer update
+}


### PR DESCRIPTION
# 概要

composer でいらなくなったパッケージを依存関係からきれいに消すためには、いくらか手順を踏む必要があるらしいので、それが必要ないようにラップコマンドを作成。